### PR TITLE
Renamed images to armbian names

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,17 +13,17 @@ if test "$1" == "image_shell"
 then
    # Shell into the SD card image. This means mounting the the image
    # and chroot 'into' the image.
-   sudo singularity run --app load_image --bind ./mirte_${2}_sd.img:/mirte_sd.img image_tools.sif
+   sudo singularity run --app load_image --bind ./${2}:/mirte_sd.img image_tools.sif
 fi
 if test "$1" == "singularity_shell"
 then
    #TODO: also bind the repos.yaml and git_local?
-   sudo singularity shell --bind ./mirte_${2}_sd.img:/mirte_sd.img image_tools.sif
+   sudo singularity shell --bind ./${2}:/mirte_sd.img image_tools.sif
 fi
 if test "$1" == "build_sd_image"
 then
-   # Determine which image to build
-   image="orangepi2"
+   # Determine which image to build (orangepizero, orangepizero2, and rpi4b supported)
+   image="orangepizero2"
    if [ $2 ]; then
       image=$2
    fi

--- a/scripts/download_image.sh
+++ b/scripts/download_image.sh
@@ -1,31 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
-raspberry_pi_link="https://cdimage.ubuntu.com/releases/20.04.5/release/ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
-orange_pi_link="https://archive.armbian.com/orangepizero/archive/Armbian_21.02.3_Orangepizero_focal_current_5.10.21.img.xz"
-orange_pi2_link="https://archive.armbian.com/orangepizero2/archive/Armbian_22.02.2_Orangepizero2_focal_legacy_4.9.255.img.xz"
+rpi4b_link="https://cdimage.ubuntu.com/releases/20.04.5/release/ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
+orangepizero_link="https://archive.armbian.com/orangepizero/archive/Armbian_21.02.3_Orangepizero_focal_current_5.10.21.img.xz"
+orangepizero2_link="https://archive.armbian.com/orangepizero2/archive/Armbian_22.02.2_Orangepizero2_focal_legacy_4.9.255.img.xz"
 
 image="custom"
-if [ "$1" = "" ] || [ "$1" = "orangepi" ]; then
-   image="orangepi"
-elif [ "$1" = "orangepi2" ]; then
-   image="orangepi2"
-elif [ "$1" = "raspberrypi" ]; then
-   image="raspberrypi"
+if [ "$1" = "" ]; then
+   image="orangepizero2"
+else
+   image=$1
 fi
 
-image_link=$orange_pi_link
-if [ "$image" = "orangepi2" ]; then
-   image_link=$orange_pi2_link
-elif [ "$image" = "raspberrypi" ]; then
-   image_link=$raspberry_pi_link
-fi
+link=$image"_link"
 
 if [ "$image" = "custom" ]; then
    cp $1 mirte_custom_sd.img
 else
    # Download and unxz the file
    # TODO:aks for permission to overwrite
-   wget -O mirte_${image}_sd.img.xz $image_link
+   wget -O mirte_${image}_sd.img.xz "${!link}"
    rm -f mirte_${image}_sd.img
    unxz mirte_${image}_sd.img.xz
 fi


### PR DESCRIPTION
This PR:

- Fixes #2 (using armbian default names)
- Removes the need for images to have the format mirte_XXX_sd.img for image_shell.