### PR TITLE
Update workflow plugin versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: setup this repo
               run: |
@@ -47,12 +47,12 @@ jobs:
               run: |
                     ./packerBuild.sh ${{ matrix.image }}
             - name: artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 path: build/*.img.xz
                 name: ${{ matrix.image }}
             - name: Push to release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   files: build/*.img.xz

--- a/.github/workflows/publish_repos.yaml
+++ b/.github/workflows/publish_repos.yaml
@@ -34,7 +34,7 @@ jobs:
                   git clone https://github.com/mirte-robot/${{ matrix.repo }}.git
                   zip -r ${{ matrix.repo }}.zip ${{ matrix.repo }}
             - name: Push to release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   files: ${{ matrix.repo }}.zip

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,7 +11,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -7,7 +7,7 @@ jobs:
   sh-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run the sh-checker
         uses: luizm/action-sh-checker@master
         env:


### PR DESCRIPTION
Tries to fix the warnings from https://github.com/ArendJan/mirte-sd-image-tools/actions/runs/9761261072 
This shouldn't break anything