### PR TITLE
3b: go back to current image due to failing wifi on v1.1

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -28,8 +28,8 @@ source "arm-image" "mirte_orangepizero2_noble" {
 
 source "arm-image" "mirte_orangepi3b" {
   image_type = "armbian"
-  iso_url = "https://github.com/ArendJan/mirte_base_images/releases/download/25.2.3/Armbian-unofficial_25.2.3_Orangepi3b_jammy_edge_6.13.3.img.xz"
-  iso_checksum = "file:https://github.com/ArendJan/mirte_base_images/releases/download/25.2.3/Armbian-unofficial_25.2.3_Orangepi3b_jammy_edge_6.13.3.img.xz.sha"
+  iso_url = "https://github.com/ArendJan/mirte_base_images/releases/download/25.11.1/Armbian-unofficial_25.11.1_Orangepi3b_jammy_current_6.12.58.img.xz"
+  iso_checksum = "file:https://github.com/ArendJan/mirte_base_images/releases/download/25.11.1/Armbian-unofficial_25.11.1_Orangepi3b_jammy_current_6.12.58.img.xz.sha"
   output_filename = "./workdir/mirte_orangepi3b.img"
   target_image_size = 15*1024*1024*1024
   # qemu_binary = ""

--- a/buildInstaller.pkr.hcl
+++ b/buildInstaller.pkr.hcl
@@ -25,8 +25,8 @@ packer {
 # }
 source "arm-image" "mirte_orangepi3b" {
   image_type = "armbian"
-  iso_url = "https://github.com/ArendJan/mirte_base_images/releases/download/25.2.3/Armbian-unofficial_25.2.3_Orangepi3b_jammy_edge_6.13.3.img.xz"
-  iso_checksum = "file:https://github.com/ArendJan/mirte_base_images/releases/download/25.2.3/Armbian-unofficial_25.2.3_Orangepi3b_jammy_edge_6.13.3.img.xz.sha"
+  iso_url = "https://github.com/ArendJan/mirte_base_images/releases/download/25.11.1/Armbian-unofficial_25.11.1_Orangepi3b_jammy_current_6.12.58.img.xz.sha"
+  iso_checksum = "file:https://github.com/ArendJan/mirte_base_images/releases/download/25.11.1/Armbian-unofficial_25.11.1_Orangepi3b_jammy_current_6.12.58.img.xz.sha.sha"
   output_filename = "./workdir/mirte_orangepi3b_installer.img"
   target_image_size = 15*1024*1024*1024
   image_arch = "arm64"


### PR DESCRIPTION
we had reports that v1.1 boards had issues with wifi after installing other updates. We originally switched to edge due to bootloader updates, but that's merged already.