### PR TITLE
Use tags when building release

### DIFF
--- a/.github/workflows/build_single.yaml
+++ b/.github/workflows/build_single.yaml
@@ -97,6 +97,14 @@ jobs:
                     cp develop_repos.yaml repos.yaml
                     echo "Using develop_repos.yaml"
                   fi
+                  # if tag, then use tag_repos.yaml, with replaced TAG with the tag name
+                  if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+                    cp tag_repos.yaml repos.yaml
+                    echo "Using tag_repos.yaml"
+                    # replace TAG with the tag name
+                    sed -i "s/TAG/${GITHUB_REF_NAME#refs\/tags\/}/g" repos.yaml
+                  fi
+
                   echo -e "MIRTE_TYPE=${{ inputs.mirte_type }}" >> settings.sh
                   ./scripts/download_uf2.sh
                   cat settings.sh

--- a/tag_repos.yaml
+++ b/tag_repos.yaml
@@ -1,0 +1,39 @@
+repositories:
+  mirte-web-interface:
+    type: git
+    url: https://github.com/mirte-robot/mirte-web-interface.git
+    version: TAG
+  mirte-telemetrix4arduino:
+    type: git
+    url: https://github.com/mirte-robot/Telemetrix4Arduino.git
+    version: TAG
+  mirte-install-scripts:
+    type: git
+    url: https://github.com/mirte-robot/mirte-install-scripts.git
+    version: TAG
+  mirte-ros-packages:
+    type: git
+    url: https://github.com/mirte-robot/mirte-ros-packages.git
+    version: TAG
+    recursive: true
+  mirte-gazebo:
+    type: git
+    url: https://github.com/mirte-robot/mirte-gazebo.git
+    version: TAG
+  mirte-oled-images:
+    type: git
+    url: https://github.com/mirte-robot/mirte-oled-images.git
+    version: TAG
+  mirte-python:
+    type: git
+    url: https://github.com/mirte-robot/mirte-python.git
+    version: TAG
+  mirte-documentation:
+    type: git
+    url: https://github.com/mirte-robot/mirte-documentation.git
+    version: TAG
+  mirte-telemetrix4rpipico:
+    type: git
+    url: https://github.com/mirte-robot/Telemetrix4RpiPico.git
+    recursive: true
+    version: TAG

--- a/tag_repos.yaml
+++ b/tag_repos.yaml
@@ -14,7 +14,7 @@ repositories:
   mirte-ros-packages:
     type: git
     url: https://github.com/mirte-robot/mirte-ros-packages.git
-    version: TAG
+    version: main # there are tags, but otherwise it will compile the packages instead of using the precompiled packages and update them.
     recursive: true
   mirte-gazebo:
     type: git


### PR DESCRIPTION
creates a repos.yaml with the tags for the repos

mirte-ros-packages uses main, as the tags don't have precompiled packages

This requires the tags to be there ( https://github.com/ArendJan/mirte-dev-scripts/blob/main/create_release.sh ), but makes it more reproducible!